### PR TITLE
Use NEXT_PUBLIC env vars as runtime vars for prod builds

### DIFF
--- a/components/Chat/ChatHeader.tsx
+++ b/components/Chat/ChatHeader.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { env } from 'next-runtime-env'
+
 import React, { useContext, useState, useRef, useEffect } from 'react';
 import { 
   IconArrowsSort, 
@@ -15,7 +17,7 @@ import { getWorkflowName } from '@/utils/app/helper';
 
 export const ChatHeader = ({ webSocketModeRef = {} }) => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const [isExpanded, setIsExpanded] = useState(process?.env?.NEXT_PUBLIC_RIGHT_MENU_OPEN === 'true' ? true : false);
+    const [isExpanded, setIsExpanded] = useState(env('NEXT_PUBLIC_RIGHT_MENU_OPEN') === 'true' || process?.env?.NEXT_PUBLIC_RIGHT_MENU_OPEN === 'true' ? true : false);
     const menuRef = useRef(null);
 
     const workflow = getWorkflowName()

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
+const { configureRuntimeEnv } = require('next-runtime-env/build/configure');
+
 const nextConfig = {
+  env: {
+    ...configureRuntimeEnv(),
+  },
   output: 'standalone',
   typescript: {
     // !! WARN !!

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-config-next": "^14.2.10",
         "gpt-3-encoder": "^1.1.4",
         "jsdom": "^21.1.1",
+        "next-runtime-env": "^1.3.0",
         "postcss": "^8.4.21",
         "prettier": "^2.8.7",
         "prettier-plugin-tailwindcss": "^0.2.5",
@@ -8101,6 +8102,92 @@
         "next": ">= 12.0.0",
         "react": ">= 17.0.2",
         "react-i18next": "^12.2.0"
+      }
+    },
+    "node_modules/next-runtime-env": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/next-runtime-env/-/next-runtime-env-1.3.0.tgz",
+      "integrity": "sha512-EZxn63AyuVzgRvTi9JFkUgKw3+Sff61QXEq1ly6psJe5dMJxERfdENXQsvJ5cfQNhnhWGZzBC8VzYgWRjUtm4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next-runtime-env/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prettier-plugin-tailwindcss": "^0.2.5",
     "tailwindcss": "^3.3.3",
     "typescript": "4.9.5",
-    "vitest": "^0.29.7"
+    "vitest": "^0.29.7",
+    "next-runtime-env": "^1.3.0"
   }
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,5 @@
 import { DocumentProps, Head, Html, Main, NextScript } from 'next/document';
 import i18nextConfig from '../next-i18next.config';
-
 type Props = DocumentProps & {
   // add custom document props
 };
@@ -13,6 +12,7 @@ export default function Document(props: Props) {
       <Head>
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="AIQ Toolkit-UI"></meta>
+        <script src="/__ENV.js" />
       </Head>
       <body>
         <Main />

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -1,6 +1,7 @@
 import { Conversation, Message } from '@/types/chat';
 import { FolderInterface } from '@/types/folder';
 import { t } from 'i18next';
+import { env } from 'next-runtime-env'
 
 export interface HomeInitialState {
   loading: boolean;
@@ -40,14 +41,14 @@ export const initialState: HomeInitialState = {
   currentFolder: undefined,
   messageError: false,
   searchTerm: '',
-  chatHistory: process?.env?.NEXT_PUBLIC_CHAT_HISTORY_DEFAULT_ON === 'true' || false,
-  chatCompletionURL: process?.env?.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL || 'http://127.0.0.1:8000/chat/stream',
-  webSocketMode: process?.env?.NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON === 'true' || false,
+  chatHistory: env('NEXT_PUBLIC_CHAT_HISTORY_DEFAULT_ON') === 'true' || process?.env?.NEXT_PUBLIC_CHAT_HISTORY_DEFAULT_ON === 'true' ? true : false,
+  chatCompletionURL: env('NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL') || process?.env?.NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL || 'http://127.0.0.1:8000/chat/stream',
+  webSocketMode: env('NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON') === 'true' || process?.env?.NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON === 'true' ? true : false,
   webSocketConnected: false,
-  webSocketURL: process?.env?.NEXT_PUBLIC_WEBSOCKET_CHAT_COMPLETION_URL || 'ws://127.0.0.1:8000/websocket',
+  webSocketURL: env('NEXT_PUBLIC_WEBSOCKET_CHAT_COMPLETION_URL') || process?.env?.NEXT_PUBLIC_WEBSOCKET_CHAT_COMPLETION_URL || 'ws://127.0.0.1:8000/websocket',
   webSocketSchema: 'chat_stream',
   webSocketSchemas: ['chat_stream', 'chat', 'generate_stream', 'generate'],
-  enableIntermediateSteps: process?.env?.NEXT_PUBLIC_ENABLE_INTERMEDIATE_STEPS ? process.env.NEXT_PUBLIC_ENABLE_INTERMEDIATE_STEPS === 'true' : true,
+  enableIntermediateSteps: env('NEXT_PUBLIC_ENABLE_INTERMEDIATE_STEPS') === 'true' || process?.env?.NEXT_PUBLIC_ENABLE_INTERMEDIATE_STEPS === 'true' ? true : false,
   expandIntermediateSteps: false,
   intermediateStepOverride: true,
   autoScroll: true,

--- a/utils/app/helper.ts
+++ b/utils/app/helper.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { env } from 'next-runtime-env'
 export const getInitials = (fullName = '') => {
     if (!fullName) {
         return "";
@@ -86,7 +87,7 @@ export const getURLQueryParam = ({ param = '' }) => {
 
 
 export const getWorkflowName = () => {
-    const workflow = getURLQueryParam({ param: 'workflow' }) || process?.env?.NEXT_PUBLIC_WORKFLOW || 'AIQ Toolkit';
+    const workflow = getURLQueryParam({ param: 'workflow' }) || env('NEXT_PUBLIC_WORKFLOW') || process?.env?.NEXT_PUBLIC_WORKFLOW || 'AIQ Toolkit';
     return workflow
 }
 


### PR DESCRIPTION
uses next-runtime-env@1.x for Page Router based logic. Once the app logic is updated to App Router, upgrade this lib version to @3.x or better.