### PR TITLE
Forwarding conversation ID in HTTP Request as Header

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -518,6 +518,7 @@ export const Chat = () => {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
+              'Thread-Id': selectedConversation?.id || '',
             },
             signal: controllerRef.current.signal, // Use ref here
             body,

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -56,6 +56,7 @@ const handler = async (req: Request): Promise<Response> => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'Thread-Id': req.headers.get('Thread-Id') || '',
       },
       body: JSON.stringify(payload),
     });


### PR DESCRIPTION
This pull request involves forwarding the conversation ID as an HTTP request header, enabling the server to associate incoming requests with a specific conversation context.